### PR TITLE
Update PsMapExec.ps1

### DIFF
--- a/PsMapExec.ps1
+++ b/PsMapExec.ps1
@@ -1424,12 +1424,12 @@ This flush operation clears the stored LDAP queries to prevent the reuse of resu
         process {
             $Computers = @()
             foreach ($subnet in $Targets) {
-                if ($subnet -match '^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$') {
-                    # Treat as a single IP address
+                if ($subnet -match '^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.?\b){4}$') {
+                    # Treat as a single IP address - added robust regex to ensure valid ranges
                     $Computers += $subnet
                 }
-                elseif ($subnet -match '^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/\d{1,2}$') {
-                    # CIDR notation processing
+                elseif ($subnet -match '^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.?\b){4}/\b(1[6-9]|2[0-9]|3[0-2])\b$') {
+                    # CIDR notation processing - added robust regex to ensure valid ranges, accepts up to /16 but will notify user to reduce mask appropriately
                     $IP = ($subnet -split '\/')[0]
                     [int]$SubnetBits = ($subnet -split '\/')[1]
                     if ($SubnetBits -lt 20 -or $SubnetBits -gt 30) {
@@ -1446,7 +1446,7 @@ This flush operation clears the stored LDAP queries to prevent the reuse of resu
                     $HostBits = 32 - $SubnetBits
                     $NetworkIDInBinary = $IPInBinary.Substring(0, $SubnetBits)
                     $HostIDInBinary = '0' * $HostBits
-                    $imax = [convert]::ToInt32(('1' * $HostBits), 2) - 2 # -2 to exclude network and broadcast addresses
+                    $imax = [convert]::ToInt32(('1' * $HostBits), 2) - 1 # -1 to exclude .255 from last octet in specified range
                     For ($i = 1; $i -le $imax; $i++) {
                         $NextHostIDInDecimal = $i
                         $NextHostIDInBinary = [convert]::ToString($NextHostIDInDecimal, 2).PadLeft($HostBits, '0')

--- a/PsMapExec.ps1
+++ b/PsMapExec.ps1
@@ -1446,7 +1446,7 @@ This flush operation clears the stored LDAP queries to prevent the reuse of resu
                     $HostBits = 32 - $SubnetBits
                     $NetworkIDInBinary = $IPInBinary.Substring(0, $SubnetBits)
                     $HostIDInBinary = '0' * $HostBits
-                    $imax = [convert]::ToInt32(('1' * $HostBits), 2) - 1 # -1 to exclude .255 from last octet in specified range
+                    $imax = [convert]::ToInt32(('1' * $HostBits), 2) - 1 # -1 to ensure last useable IP in range is included but not the broadcast IP
                     For ($i = 1; $i -le $imax; $i++) {
                         $NextHostIDInDecimal = $i
                         $NextHostIDInBinary = [convert]::ToString($NextHostIDInDecimal, 2).PadLeft($HostBits, '0')


### PR DESCRIPTION
Added more robust regex's for the Get-IPRange function. CIDR regex allows for users to enter from /16 to /32 but will notify users if the range is too big or small to allow users to adjust the range. Will give invalid format error if outside of those ranges.

Changed the $imax calculation to ensure that last useable IP in range is being scanned. it is currently dropping the last useable IP :)